### PR TITLE
Support threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Mac:
 ```
 sudo curl https://bootstrap.pypa.io/get-pip.py | python3
 pip3 install discord.py
-pip3 install tk
 ```
 or if using Homebrew:
 ```
@@ -43,7 +42,6 @@ Windows:
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 python get-pip.py
 pip install discord.py
-pip install tk
 ```
 
 5. Run the Slackord executable file, or run Python script by with `python3 slackord.py`, or `py slackord.py`.

--- a/README.md
+++ b/README.md
@@ -20,33 +20,33 @@ Alternatively, you can download the slackord.py script here and run it directly 
 1. Make sure you've installed Python3+ from https://www.python.org/downloads/. Tkinter comes bundled with Mac/Windows Python releases.
 1. Install the Discord python wrapper/tk:
 
-Ubuntu:
-```
-sudo apt-get install -y python3 python3-pip python-tk; python3 -m pip install discord.py
-```
+    Ubuntu:
+    ```
+    sudo apt-get install -y python3 python3-pip python-tk; python3 -m pip install discord.py
+    ```
 
-RHEL/Centos:
-```
-sudo yum install -y python3 tkinter python3-pip; python3 -m pip install discord.py
-```
+    RHEL/Centos:
+    ```
+    sudo yum install -y python3 tkinter python3-pip; python3 -m pip install discord.py
+    ```
 
-Mac:
-```
-sudo curl https://bootstrap.pypa.io/get-pip.py | python3; pip3 install discord.py
-```
-or if using Homebrew:
-```
-brew install python-tk.
-```
+    Mac:
+    ```
+    sudo curl https://bootstrap.pypa.io/get-pip.py | python3; pip3 install discord.py
+    ```
+    or if using Homebrew:
+    ```
+    brew install python-tk.
+    ```
 
-Windows:
-```
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-python get-pip.py
-pip install discord.py
-```
+    Windows:
+    ```
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+    python get-pip.py
+    pip install discord.py
+    ```
 
-5. Run the Slackord executable file, or run Python script by with `python3 slackord.py`, or `py slackord.py`.
-6. Click "Import JSON File", browse and select the Slack chat file you wish to import to Discord.
-7. Click "Enter Bot Token" and paste your bot's token into the field and press enter.
-8. Enter any Discord channel and type !slackord. Messages will now post to that channel.
+1. Run the Slackord executable file, or run Python script by with `python3 slackord.py`, or `py slackord.py`.
+1. Click "Import JSON File", browse and select the Slack chat file you wish to import to Discord.
+1. Click "Enter Bot Token" and paste your bot's token into the field and press enter.
+1. Enter any Discord channel and type !slackord. Messages will now post to that channel.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Alternatively, you can download the slackord.py script here and run it directly 
 
 # Instructions:
 
+1. Export your Slack data as JSON.  Note that only public channels are
+   included if you have the Free or Pro version. You need a Business+
+   or Enterprise Grid plan to export private channels and direct
+   messages (DMs).
+   https://slack.com/help/articles/201658943-Export-your-workspace-data
 1. Set up Discord bot and create a token here https://discordapp.com/developers/applications/.
 1. Clone this repo or download the python file. `git clone `
 1. Make sure you've installed Python3 from https://www.python.org/downloads/.

--- a/slackord.py
+++ b/slackord.py
@@ -57,7 +57,7 @@ def parse_json_slack_export(filename):
       - the first item is the formatted string of a message ready to post to discord
       - the second item is a dict if this message has a thread, otherwise None.
         - the keys are the timestamps of the messages within the thread
-        - the values are the formatting strings of the messages within the thread
+        - the values are the formatted strings of the messages within the thread
     """
     parsed_messages = dict()
     with open(filename) as f:

--- a/slackord.py
+++ b/slackord.py
@@ -42,6 +42,7 @@ def SpawnTokenWindow():
         frameBox.yview(tk.END)
     else:
         # TODO: Thread this process with bot.start().
+        # XXX the bot is functional, but the GUI hangs after entering the token and never returns
         bot.run(botToken)
 
 
@@ -64,6 +65,8 @@ def Output():
         # When !slackord is typed in a channel, iterate through the JSON file and post each message.
         @bot.command(pass_context=True)
         async def slackord(ctx):
+            # XXX none of the Tk output here is visible
+            #     possibly related to bot.run() vs. bot.start() above
             frameBox.insert(tk.END, 'Posting messages into Discord!')
             frameBox.yview(tk.END)
             with open(filename) as f:
@@ -77,6 +80,7 @@ def Output():
                         # Output to the GUI that the message was posted.
                         frameBox.insert(tk.END, 'Message posted!')
                         frameBox.yview(tk.END)
+            frameBox.insert(tk.END, 'Done posting messages')
 
 
 # Begin tkinter setup.

--- a/slackord.py
+++ b/slackord.py
@@ -91,13 +91,18 @@ def parse_json_slack_export(filename):
 def Output():
     filename = tk.filedialog.askopenfilename()
     parsed_messages = parse_json_slack_export(filename)
-    frameBox.insert(
-        tk.END, f"Slackord will post the following {len(parsed_messages)} messages to your desired Discord channel:")
+    frameBox.insert(tk.END,
+                    f"Slackord will post the following {len(parsed_messages)} messages"
+                    " (plus thread contents if applicable) to your desired Discord channel:")
     frameBox.yview(tk.END)
     for timestamp in sorted(parsed_messages.keys()):
         # XXX not yet accounting for messages within thread
         (message, thread) = parsed_messages[timestamp]
         frameBox.insert(tk.END, message)
+        if thread:
+            for timestamp_in_thread in sorted(thread.keys()):
+                thread_message = thread[timestamp_in_thread]
+                frameBox.insert(tk.END, f"\t{thread_message}")
         frameBox.yview(tk.END)
 
     # When !slackord is typed in a channel, iterate through the JSON file and post each message.


### PR DESCRIPTION
This adds support for threads.

Previously, all messages, even if they originated in a thread, were posted directly to the main channel.
Now we only post the non-threaded messages to the main channel.
If there is a thread, create a thread at that message, then post the messages in the thread.
Calls to `sorted()` ensure that both the messages in the main channel, and those within a thread, are posted in order.
I suspect this is not needed, as the JSON file (in limited tests) appears to be ordered, but it doesn't hurt.

Rather than repeat the JSON file parsing, we instead parse it just once, when the file is input, and build up a dict with the relevant contents. See the docstring of `parse_json_slack_export()` for details. The actual bot implementation no longer references the file, and instead iterates through this dict.

There are still issues with the blocking nature of the GUI and it hanging after entering the token, but resolving that is out of scope.
To compensate, there are bare print statements added in the bot command method (`slackord(ctx)`) for now, since nothing output to the GUI in that method is ever seen.