### PR TITLE
Fix orphaned thread

### DIFF
--- a/slackord.py
+++ b/slackord.py
@@ -12,6 +12,7 @@ import tkinter as tk
 from tkinter.filedialog import askopenfilename
 from tkinter import *
 from tkinter import simpledialog
+from warnings import warn
 
 intents = discord.Intents.default()
 intents.messages = True


### PR DESCRIPTION
The orphaned thread case (where we can't find the root of the thread to which a message belongs) didn't work, because of a missing import (for the warning).

In addition to fixing that, this also handles the case better, creating a fake root to replace the missing one, so that if there is more than one message in the same thread, they will still be grouped together.